### PR TITLE
Fix comment to hide loading in literary characters

### DIFF
--- a/notebooks/Literary_Characters.ipynb
+++ b/notebooks/Literary_Characters.ipynb
@@ -34,7 +34,7 @@
    },
    "outputs": [],
    "source": [
-    "#HIDDEN\n",
+    "# HIDDEN\n",
     "# Read two books, fast!  (We're just repeating the setup from the previous section.)\n",
     "huck_finn_url = 'https://github.com/data-8/data8assets/raw/gh-pages/lec/huck_finn.txt'\n",
     "huck_finn_text = read_url(huck_finn_url)\n",


### PR DESCRIPTION
I think this second python block is supposed to be hidden in the gitbook output. I'm guessing the lack of space between `#` and `HIDDEN` is what's causing it to show up
