### PR TITLE
Add explanation of range arguments

### DIFF
--- a/notebooks/Ranges.ipynb
+++ b/notebooks/Ranges.ipynb
@@ -21,6 +21,8 @@
     "\n",
     "Ranges are defined  using the `np.arange` function, which takes either one, two, or three arguments: a start, and end, and a 'step'.\n",
     "\n",
+    "If you pass one argument to `np.arange`, this becomes the `end` value, with `start=0`, `step=1` assumed.  Two arguments give the `start` and `end` with `step=1` assumed.  Three arguments give the `start`, `end` and `step` explicitly.\n",
+    "\n",
     "A range always includes its `start` value, but does not include its `end` value.  It counts up by `step`, and it stops before it gets to the `end`.\n",
     "\n",
     "    np.arange(end): An array starting with 0 of increasing consecutive integers, stopping before end."


### PR DESCRIPTION
It's a bit difficult to follow the discussion of end etc without knowing
how the input arguments work.   Add suggested explanation.

I know the explanation is implied by the later typewriter font one-line summaries, but it wasn't obvious to me when I first read it.