### PR TITLE
WIP: Add docker workflow.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,21 @@
-FROM andrewosh/binder-base
+FROM node:8.5.0-stretch
 
-MAINTAINER Sam Lau <samlau95@gmail.com>
+ENV BOOKDIR /gitbook
+WORKDIR $BOOKDIR
 
+EXPOSE 4000 35729
 
-# RUN /bin/bash -c 'source activate python3; pip install -I datascience'
+RUN apt update
+RUN apt -y install make python3-pip
 
+ADD . $BOOKDIR
+
+RUN pip3 install -r requirements.txt 
+
+RUN npm install --global gitbook-cli
+RUN gitbook fetch latest
+RUN gitbook install
+RUN gitbook update
+RUN python3 convert_notebooks_to_html_partial.py
+RUN gitbook build
+CMD [ "gitbook", "--help" ]

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ notebooks:
 	@echo "${BLUE}Converting notebooks to HTML.${NOCOLOR}"
 	@echo "${BLUE}=============================${NOCOLOR}"
 
-	python convert_notebooks_to_html_partial.py
+	python3 convert_notebooks_to_html_partial.py
 
 	@echo ""
 	@echo "${BLUE}    Done, output is in notebooks-html${NOCOLOR}"

--- a/book.json
+++ b/book.json
@@ -1,6 +1,6 @@
 {
     "gitbook": "3.x.x",
-    "plugins": [ "mathjax@git+https://github.com/data-8/plugin-mathjax" ],
+    "plugins": [ "mathjax" ],
     "links": {
         "sidebar": {
             "Main Data Science 8 Site": "http://data8.org/"

--- a/convert_notebooks_to_html_partial.py
+++ b/convert_notebooks_to_html_partial.py
@@ -119,8 +119,8 @@ def convert_notebooks_to_html_partial(notebook_paths):
 
         # Write out HTML
         outfile_path = os.path.join(os.curdir, NOTEBOOK_HTML_DIR, outfile_name)
-        with open(outfile_path, 'w') as outfile:
-            outfile.write(final_output)
+        with open(outfile_path, 'wb') as outfile:
+            outfile.write(final_output.encode('utf-8'))
 
         # Write out images
         for relative_path, image_data in resources['outputs'].items():

--- a/convert_notebooks_to_html_partial.py
+++ b/convert_notebooks_to_html_partial.py
@@ -46,7 +46,7 @@ NOTEBOOK_IMAGE_DIR = 'notebooks-images'
 
 # The prefix for the interact button links. The path format string gets filled
 # in with the notebook as well as any datasets the notebook requires.
-INTERACT_LINK = 'https://data8.haas.berkeley.edu/user-redirect/interact?repo=textbook&{paths}'
+INTERACT_LINK = 'https://datahub.berkeley.edu/user-redirect/interact?repo=textbook&{paths}'
 
 # The prefix for each notebook + its dependencies
 PATH_PREFIX = 'path=notebooks/{}'

--- a/convert_notebooks_to_html_partial.py
+++ b/convert_notebooks_to_html_partial.py
@@ -46,7 +46,7 @@ NOTEBOOK_IMAGE_DIR = 'notebooks-images'
 
 # The prefix for the interact button links. The path format string gets filled
 # in with the notebook as well as any datasets the notebook requires.
-INTERACT_LINK = 'https://datahub.berkeley.edu/user-redirect/interact?repo=textbook&{paths}'
+INTERACT_LINK = 'http://datahub.berkeley.edu/user-redirect/interact?repo=textbook&{paths}'
 
 # The prefix for each notebook + its dependencies
 PATH_PREFIX = 'path=notebooks/{}'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+beautifulsoup4==4.6.0
+nbconvert==5.3.1
+nbformat==4.4.0


### PR DESCRIPTION
With these changes, the textbook can be reproducibly built and served with:
```
docker build -t data8-textbook .
docker run -p 4000:4000 -p 35729:35729 -it data8-textbook gitbook serve
```
I switched from the data-8 mathjax to upstream since the former produced build errors. I don't know how will alter math rendering.

I think this workflow will ultimately help migrate the builds to CI.