### PR TITLE
Delete line `# HIDDEN` to show missing graph

### DIFF
--- a/notebooks/14/1/Properties_of_the_Mean.ipynb
+++ b/notebooks/14/1/Properties_of_the_Mean.ipynb
@@ -518,7 +518,6 @@
     }
    ],
    "source": [
-    "# HIDDEN\n",
     "\n",
     "t2 = t2.with_column(\n",
     "        'not_symmetric', make_array(0.25, 0.5, 0, 0.25)\n",


### PR DESCRIPTION
When reading Ch. 14/1, the text seems to suggest there should be a graph in between sentences. Looking at the raw `.ipynb` code, there is a graph but it is not shown when the notebook gets built because of `# HIDDEN` directive. This commit fixes it.

Relevant section of the textbook:

> In general, for symmetric distributions, the mean and the median are equal.
>
> What if the distribution is not symmetric? Let’s compare symmetric and not_symmetric.
> 
> The blue histogram represents the original symmetric distribution. The gold histogram of not_symmetric starts out the same as the blue at the left end, but its rightmost bar has slid over to the value 9. The brown part is where the two histograms overlap.
> 
> The median and mean of the blue distribution are both equal to 3. The median of the gold distribution is also equal to 3, though the right half is distributed differently from the left.