### PR TITLE
Fix inconsistent indentation for code

### DIFF
--- a/_sass/components/_components.textbook__page.scss
+++ b/_sass/components/_components.textbook__page.scss
@@ -73,8 +73,6 @@
 
 /* [5] */
 code {
-  padding: 4px;
-
   @include inuit-font-size(14px);
 }
 


### PR DESCRIPTION
Fixes #86

I believe this should fix the issue where the first line of code cells is indented more than the others.