### PR TITLE
Fix misspelling and missing latex symbols

### DIFF
--- a/content/chapters/15/6/Numerical_Diagnostics.ipynb
+++ b/content/chapters/15/6/Numerical_Diagnostics.ipynb
@@ -407,7 +407,7 @@
     "\\frac{\\mbox{SD of residuals}}{\\mbox{SD of }y} ~=~ \\sqrt{1-r^2}\n",
     "$$\n",
     "\n",
-    "A complentary result is that no matter what the shape of the scatter plot, the SD of the fitted values is a fraction of the SD of the observed values of $y$. The fraction is |r|.\n",
+    "A complementary result is that no matter what the shape of the scatter plot, the SD of the fitted values is a fraction of the SD of the observed values of $y$. The fraction is $|r|$.\n",
     "\n",
     "$$\n",
     "\\frac{\\mbox{SD of fitted values}}{\\mbox{SD of }y} ~=~ |r|\n",


### PR DESCRIPTION
There's funky formatting happening around the |r| in the rendered textbook, and my guess is that it's due to the lack of latex symbols around the piped fraction.

<img width="761" alt="screen shot 2019-01-24 at 8 11 16 pm" src="https://user-images.githubusercontent.com/297042/51724885-4b85b780-2014-11e9-9fd2-208f38b5e063.png">

Double checking my work would be great, though! I only tested in Jupyter.