### PR TITLE
removing # HIDDEN and using tags

### DIFF
--- a/content/chapters/01/3/1/Literary_Characters.ipynb
+++ b/content/chapters/01/3/1/Literary_Characters.ipynb
@@ -3,10 +3,13 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "remove_cell"
+    ]
+   },
    "outputs": [],
    "source": [
-    "# HIDDEN\n",
     "from datascience import *\n",
     "import numpy as np\n",
     "path_data = '../../../../../data/'\n",
@@ -27,10 +30,13 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "remove_cell"
+    ]
+   },
    "outputs": [],
    "source": [
-    "# HIDDEN\n",
     "\n",
     "# Read two books, fast (again)!\n",
     "\n",

--- a/content/chapters/01/3/2/Another_Kind_Of_Character.ipynb
+++ b/content/chapters/01/3/2/Another_Kind_Of_Character.ipynb
@@ -3,10 +3,13 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "remove_cell"
+    ]
+   },
    "outputs": [],
    "source": [
-    "# HIDDEN\n",
     "from datascience import *\n",
     "import numpy as np\n",
     "path_data = '../../../../../data/'\n",
@@ -27,10 +30,13 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "remove_cell"
+    ]
+   },
    "outputs": [],
    "source": [
-    "# HIDDEN\n",
     "\n",
     "# Read two books, fast (again)!\n",
     "\n",

--- a/content/chapters/01/3/Plotting_the_Classics.ipynb
+++ b/content/chapters/01/3/Plotting_the_Classics.ipynb
@@ -3,10 +3,13 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "remove_cell"
+    ]
+   },
    "outputs": [],
    "source": [
-    "# HIDDEN\n",
     "from datascience import *\n",
     "from datascience.predicates import are\n",
     "path_data = '../../../../data/'\n",

--- a/content/chapters/03/4/Introduction_to_Tables.ipynb
+++ b/content/chapters/03/4/Introduction_to_Tables.ipynb
@@ -4,11 +4,13 @@
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "tags": [
+     "remove_cell"
+    ]
    },
    "outputs": [],
    "source": [
-    "# HIDDEN\n",
     "\n",
     "from datascience import *\n",
     "path_data = '../../../../data/'\n",

--- a/content/chapters/05/1/Arrays.ipynb
+++ b/content/chapters/05/1/Arrays.ipynb
@@ -4,11 +4,13 @@
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "tags": [
+     "remove_cell"
+    ]
    },
    "outputs": [],
    "source": [
-    "# HIDDEN\n",
     "from datascience import *\n",
     "path_data = '../../../../data/'"
    ]

--- a/content/chapters/05/2/Ranges.ipynb
+++ b/content/chapters/05/2/Ranges.ipynb
@@ -4,11 +4,13 @@
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "tags": [
+     "remove_cell"
+    ]
    },
    "outputs": [],
    "source": [
-    "# HIDDEN\n",
     "import numpy as np\n",
     "path_data = '../../../../data/'"
    ]

--- a/content/chapters/05/3/More_on_Arrays.ipynb
+++ b/content/chapters/05/3/More_on_Arrays.ipynb
@@ -3,10 +3,13 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "remove_cell"
+    ]
+   },
    "outputs": [],
    "source": [
-    "# HIDDEN\n",
     "from datascience import *\n",
     "import numpy as np\n",
     "path_data = '../../../../data/'"

--- a/content/chapters/05/Sequences.ipynb
+++ b/content/chapters/05/Sequences.ipynb
@@ -3,10 +3,13 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "remove_cell"
+    ]
+   },
    "outputs": [],
    "source": [
-    "# HIDDEN\n",
     "from datascience import *\n",
     "path_data = '../../../data/'"
    ]

--- a/content/chapters/06/1/Sorting_Rows.ipynb
+++ b/content/chapters/06/1/Sorting_Rows.ipynb
@@ -4,11 +4,13 @@
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "tags": [
+     "remove_cell"
+    ]
    },
    "outputs": [],
    "source": [
-    "# HIDDEN\n",
     "from datascience import *\n",
     "import numpy as np\n",
     "path_data = '../../../../data/'\n",

--- a/content/chapters/06/2/Selecting_Rows.ipynb
+++ b/content/chapters/06/2/Selecting_Rows.ipynb
@@ -4,11 +4,13 @@
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "tags": [
+     "remove_cell"
+    ]
    },
    "outputs": [],
    "source": [
-    "# HIDDEN\n",
     "from datascience import *\n",
     "import numpy as np\n",
     "path_data = '../../../../data/'\n",
@@ -19,11 +21,13 @@
    "cell_type": "code",
    "execution_count": 2,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "tags": [
+     "remove_cell"
+    ]
    },
    "outputs": [],
    "source": [
-    "# HIDDEN\n",
     "nba_salaries = Table.read_table(path_data + 'nba_salaries.csv')\n",
     "nba = nba_salaries.relabeled(\"'15-'16 SALARY\", 'SALARY')"
    ]

--- a/content/chapters/06/3/Example_Trends_in_the_Population_of_the_United_States.ipynb
+++ b/content/chapters/06/3/Example_Trends_in_the_Population_of_the_United_States.ipynb
@@ -4,11 +4,13 @@
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "tags": [
+     "remove_cell"
+    ]
    },
    "outputs": [],
    "source": [
-    "# HIDDEN\n",
     "from datascience import *\n",
     "import numpy as np\n",
     "path_data = '../../../../data/'\n",

--- a/content/chapters/06/4/Example_Gender_Ratio_in_the_US_Population.ipynb
+++ b/content/chapters/06/4/Example_Gender_Ratio_in_the_US_Population.ipynb
@@ -4,11 +4,13 @@
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "tags": [
+     "remove_cell"
+    ]
    },
    "outputs": [],
    "source": [
-    "# HIDDEN\n",
     "from datascience import *\n",
     "import numpy as np\n",
     "path_data = '../../../../data/'\n",
@@ -26,11 +28,13 @@
    "cell_type": "code",
    "execution_count": 2,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "tags": [
+     "remove_cell"
+    ]
    },
    "outputs": [],
    "source": [
-    "# HIDDEN\n",
     "# As of Jan 2017, this census file is online here: \n",
     "data = 'http://www2.census.gov/programs-surveys/popest/datasets/2010-2015/national/asrh/nc-est2015-agesex-res.csv'\n",
     "\n",

--- a/content/chapters/06/Tables.ipynb
+++ b/content/chapters/06/Tables.ipynb
@@ -4,11 +4,13 @@
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "tags": [
+     "remove_cell"
+    ]
    },
    "outputs": [],
    "source": [
-    "# HIDDEN\n",
     "import numpy as np\n",
     "np.set_printoptions(threshold=50)\n",
     "path_data = '../../../data/'"

--- a/content/chapters/07/1/Visualizing_Categorical_Distributions.ipynb
+++ b/content/chapters/07/1/Visualizing_Categorical_Distributions.ipynb
@@ -4,11 +4,13 @@
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "tags": [
+     "remove_cell"
+    ]
    },
    "outputs": [],
    "source": [
-    "# HIDDEN\n",
     "from datascience import *\n",
     "import matplotlib\n",
     "path_data = '../../../../data/'\n",

--- a/content/chapters/07/2/Visualizing_Numerical_Distributions.ipynb
+++ b/content/chapters/07/2/Visualizing_Numerical_Distributions.ipynb
@@ -3,10 +3,13 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "remove_cell"
+    ]
+   },
    "outputs": [],
    "source": [
-    "# HIDDEN\n",
     "from datascience import *\n",
     "import numpy as np\n",
     "path_data = '../../../../data/'\n",

--- a/content/chapters/07/3/Overlaid_Graphs.ipynb
+++ b/content/chapters/07/3/Overlaid_Graphs.ipynb
@@ -4,11 +4,13 @@
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "tags": [
+     "remove_cell"
+    ]
    },
    "outputs": [],
    "source": [
-    "# HIDDEN\n",
     "from datascience import *\n",
     "import numpy as np\n",
     "path_data = '../../../../data/'\n",

--- a/content/chapters/07/Visualization.ipynb
+++ b/content/chapters/07/Visualization.ipynb
@@ -4,11 +4,13 @@
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "tags": [
+     "remove_cell"
+    ]
    },
    "outputs": [],
    "source": [
-    "# HIDDEN\n",
     "from datascience import *\n",
     "import matplotlib\n",
     "path_data = '../../../data/'\n",

--- a/content/chapters/08/1/Applying_a_Function_to_a_Column.ipynb
+++ b/content/chapters/08/1/Applying_a_Function_to_a_Column.ipynb
@@ -4,11 +4,13 @@
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "tags": [
+     "remove_cell"
+    ]
    },
    "outputs": [],
    "source": [
-    "# HIDDEN\n",
     "from datascience import *\n",
     "import matplotlib\n",
     "path_data = '../../../../data/'\n",

--- a/content/chapters/08/2/Classifying_by_One_Variable.ipynb
+++ b/content/chapters/08/2/Classifying_by_One_Variable.ipynb
@@ -4,11 +4,13 @@
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "tags": [
+     "remove_cell"
+    ]
    },
    "outputs": [],
    "source": [
-    "# HIDDEN\n",
     "\n",
     "from datascience import *\n",
     "path_data = '../../../../data/'\n",

--- a/content/chapters/08/3/Cross-Classifying_by_More_than_One_Variable.ipynb
+++ b/content/chapters/08/3/Cross-Classifying_by_More_than_One_Variable.ipynb
@@ -4,11 +4,13 @@
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "tags": [
+     "remove_cell"
+    ]
    },
    "outputs": [],
    "source": [
-    "# HIDDEN\n",
     "\n",
     "from datascience import *\n",
     "path_data = '../../../../data/'\n",

--- a/content/chapters/08/4/Joining_Tables_by_Columns.ipynb
+++ b/content/chapters/08/4/Joining_Tables_by_Columns.ipynb
@@ -4,11 +4,13 @@
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "tags": [
+     "remove_cell"
+    ]
    },
    "outputs": [],
    "source": [
-    "# HIDDEN\n",
     "\n",
     "from datascience import *\n",
     "path_data = '../../../../data/'\n",

--- a/content/chapters/08/5/Bike_Sharing_in_the_Bay_Area.ipynb
+++ b/content/chapters/08/5/Bike_Sharing_in_the_Bay_Area.ipynb
@@ -3,10 +3,13 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "remove_cell"
+    ]
+   },
    "outputs": [],
    "source": [
-    "# HIDDEN\n",
     "from datascience import *\n",
     "%matplotlib inline\n",
     "path_data = '../../../../data/'\n",

--- a/content/chapters/08/Functions_and_Tables.ipynb
+++ b/content/chapters/08/Functions_and_Tables.ipynb
@@ -4,11 +4,13 @@
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "tags": [
+     "remove_cell"
+    ]
    },
    "outputs": [],
    "source": [
-    "# HIDDEN\n",
     "from datascience import *\n",
     "import matplotlib\n",
     "path_data = '../../../data/'\n",

--- a/content/chapters/09/1/Conditional_Statements.ipynb
+++ b/content/chapters/09/1/Conditional_Statements.ipynb
@@ -3,10 +3,13 @@
   {
    "cell_type": "code",
    "execution_count": 23,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "remove_cell"
+    ]
+   },
    "outputs": [],
    "source": [
-    "# HIDDEN\n",
     "\n",
     "from datascience import *\n",
     "path_data = '../../../../data/'\n",

--- a/content/chapters/09/2/Iteration.ipynb
+++ b/content/chapters/09/2/Iteration.ipynb
@@ -3,10 +3,13 @@
   {
    "cell_type": "code",
    "execution_count": 25,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "remove_cell"
+    ]
+   },
    "outputs": [],
    "source": [
-    "# HIDDEN\n",
     "\n",
     "from datascience import *\n",
     "path_data = '../../../../data/'\n",

--- a/content/chapters/09/3/Simulation.ipynb
+++ b/content/chapters/09/3/Simulation.ipynb
@@ -4,11 +4,13 @@
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "tags": [
+     "remove_cell"
+    ]
    },
    "outputs": [],
    "source": [
-    "# HIDDEN\n",
     "\n",
     "from datascience import *\n",
     "path_data = '../../../../data/'\n",

--- a/content/chapters/09/4/Monty_Hall_Problem.ipynb
+++ b/content/chapters/09/4/Monty_Hall_Problem.ipynb
@@ -3,10 +3,13 @@
   {
    "cell_type": "code",
    "execution_count": 24,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "remove_cell"
+    ]
+   },
    "outputs": [],
    "source": [
-    "# HIDDEN\n",
     "\n",
     "from datascience import *\n",
     "path_data = '../../../../data/'\n",

--- a/content/chapters/09/5/Finding_Probabilities.ipynb
+++ b/content/chapters/09/5/Finding_Probabilities.ipynb
@@ -6,11 +6,13 @@
    "metadata": {
     "collapsed": true,
     "deletable": true,
-    "editable": true
+    "editable": true,
+    "tags": [
+     "remove_cell"
+    ]
    },
    "outputs": [],
    "source": [
-    "# HIDDEN\n",
     "\n",
     "from datascience import *\n",
     "path_data = '../../../../data/'\n",

--- a/content/chapters/09/Randomness.ipynb
+++ b/content/chapters/09/Randomness.ipynb
@@ -6,11 +6,13 @@
    "metadata": {
     "collapsed": true,
     "deletable": true,
-    "editable": true
+    "editable": true,
+    "tags": [
+     "remove_cell"
+    ]
    },
    "outputs": [],
    "source": [
-    "# HIDDEN\n",
     "\n",
     "from datascience import *\n",
     "path_data = '../../../data/'\n",

--- a/content/chapters/10/1/Empirical_Distributions.ipynb
+++ b/content/chapters/10/1/Empirical_Distributions.ipynb
@@ -3,10 +3,13 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "remove_cell"
+    ]
+   },
    "outputs": [],
    "source": [
-    "# HIDDEN\n",
     "\n",
     "from datascience import *\n",
     "path_data = '../../../../data/'\n",

--- a/content/chapters/10/2/Sampling_from_a_Population.ipynb
+++ b/content/chapters/10/2/Sampling_from_a_Population.ipynb
@@ -3,10 +3,13 @@
   {
    "cell_type": "code",
    "execution_count": 13,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "remove_cell"
+    ]
+   },
    "outputs": [],
    "source": [
-    "# HIDDEN\n",
     "\n",
     "from datascience import *\n",
     "path_data = '../../../../data/'\n",

--- a/content/chapters/10/3/Empirical_Distribution_of_a_Statistic.ipynb
+++ b/content/chapters/10/3/Empirical_Distribution_of_a_Statistic.ipynb
@@ -3,10 +3,13 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "remove_cell"
+    ]
+   },
    "outputs": [],
    "source": [
-    "# HIDDEN\n",
     "from datascience import *\n",
     "%matplotlib inline\n",
     "path_data = '../../../../data/'\n",

--- a/content/chapters/10/Sampling_and_Empirical_Distributions.ipynb
+++ b/content/chapters/10/Sampling_and_Empirical_Distributions.ipynb
@@ -4,11 +4,13 @@
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "tags": [
+     "remove_cell"
+    ]
    },
    "outputs": [],
    "source": [
-    "# HIDDEN\n",
     "\n",
     "from datascience import *\n",
     "path_data = '../../../data/'\n",

--- a/content/chapters/11/1/Assessing_Models.ipynb
+++ b/content/chapters/11/1/Assessing_Models.ipynb
@@ -3,10 +3,13 @@
   {
    "cell_type": "code",
    "execution_count": 32,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "remove_cell"
+    ]
+   },
    "outputs": [],
    "source": [
-    "# HIDDEN\n",
     "from datascience import *\n",
     "%matplotlib inline\n",
     "path_data = '../../../../data/'\n",

--- a/content/chapters/11/2/Multiple_Categories.ipynb
+++ b/content/chapters/11/2/Multiple_Categories.ipynb
@@ -3,10 +3,13 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "remove_cell"
+    ]
+   },
    "outputs": [],
    "source": [
-    "# HIDDEN\n",
     "from datascience import *\n",
     "%matplotlib inline\n",
     "path_data = '../../../../data/'\n",
@@ -19,11 +22,13 @@
    "cell_type": "code",
    "execution_count": 2,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "tags": [
+     "remove_cell"
+    ]
    },
    "outputs": [],
    "source": [
-    "# HIDDEN\n",
     "def proportions_from_distribution(table, label, sample_size):\n",
     "    proportions = np.random.multinomial(sample_size, table.column(label))/sample_size\n",
     "    return table.with_column('Random Sample', proportions)"

--- a/content/chapters/11/3/Decisions_and_Uncertainty.ipynb
+++ b/content/chapters/11/3/Decisions_and_Uncertainty.ipynb
@@ -3,10 +3,13 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "remove_cell"
+    ]
+   },
    "outputs": [],
    "source": [
-    "# HIDDEN\n",
     "from datascience import *\n",
     "%matplotlib inline\n",
     "path_data = '../../../../data/'\n",

--- a/content/chapters/11/4/Error_Probabilities.ipynb
+++ b/content/chapters/11/4/Error_Probabilities.ipynb
@@ -3,10 +3,13 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "remove_cell"
+    ]
+   },
    "outputs": [],
    "source": [
-    "# HIDDEN\n",
     "from datascience import *\n",
     "%matplotlib inline\n",
     "import matplotlib.pyplot as plots\n",
@@ -66,7 +69,11 @@
   {
    "cell_type": "code",
    "execution_count": 76,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "remove_cell"
+    ]
+   },
    "outputs": [
     {
      "data": {
@@ -80,7 +87,6 @@
     }
    ],
    "source": [
-    "# HIDDEN\n",
     "fair_coin = [1, 0]\n",
     "\n",
     "def one_simulated_statistic():\n",

--- a/content/chapters/12/1/AB_Testing.ipynb
+++ b/content/chapters/12/1/AB_Testing.ipynb
@@ -3,10 +3,13 @@
   {
    "cell_type": "code",
    "execution_count": 59,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "remove_cell"
+    ]
+   },
    "outputs": [],
    "source": [
-    "# HIDDEN\n",
     "\n",
     "from datascience import *\n",
     "path_data = '../../../../data/'\n",

--- a/content/chapters/12/2/Deflategate.ipynb
+++ b/content/chapters/12/2/Deflategate.ipynb
@@ -3,10 +3,13 @@
   {
    "cell_type": "code",
    "execution_count": 17,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "remove_cell"
+    ]
+   },
    "outputs": [],
    "source": [
-    "# HIDDEN\n",
     "from datascience import *\n",
     "%matplotlib inline\n",
     "path_data = '../../../../data/'\n",

--- a/content/chapters/12/3/Causality.ipynb
+++ b/content/chapters/12/3/Causality.ipynb
@@ -3,10 +3,13 @@
   {
    "cell_type": "code",
    "execution_count": 36,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "remove_cell"
+    ]
+   },
    "outputs": [],
    "source": [
-    "# HIDDEN\n",
     "from datascience import *\n",
     "%matplotlib inline\n",
     "path_data = '../../../../data/'\n",

--- a/content/chapters/12/Comparing_Two_Samples.ipynb
+++ b/content/chapters/12/Comparing_Two_Samples.ipynb
@@ -4,11 +4,13 @@
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "tags": [
+     "remove_cell"
+    ]
    },
    "outputs": [],
    "source": [
-    "# HIDDEN\n",
     "import matplotlib\n",
     "from datascience import *\n",
     "path_data = '../../../data/'\n",

--- a/content/chapters/13/1/Percentiles.ipynb
+++ b/content/chapters/13/1/Percentiles.ipynb
@@ -4,11 +4,13 @@
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "tags": [
+     "remove_cell"
+    ]
    },
    "outputs": [],
    "source": [
-    "# HIDDEN\n",
     "from datascience import *\n",
     "%matplotlib inline\n",
     "path_data = '../../../../data/'\n",

--- a/content/chapters/13/2/Bootstrap.ipynb
+++ b/content/chapters/13/2/Bootstrap.ipynb
@@ -3,10 +3,13 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "remove_cell"
+    ]
+   },
    "outputs": [],
    "source": [
-    "# HIDDEN\n",
     "from datascience import *\n",
     "%matplotlib inline\n",
     "path_data = '../../../../data/'\n",
@@ -490,7 +493,11 @@
   {
    "cell_type": "code",
    "execution_count": 13,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "remove_cell"
+    ]
+   },
    "outputs": [
     {
      "data": {
@@ -505,7 +512,6 @@
     }
    ],
    "source": [
-    "# HIDDEN\n",
     "\n",
     "from IPython.display import Image\n",
     "Image(\"../../../images/bootstrap_pic.png\")"

--- a/content/chapters/13/3/Confidence_Intervals.ipynb
+++ b/content/chapters/13/3/Confidence_Intervals.ipynb
@@ -4,11 +4,13 @@
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "tags": [
+     "remove_cell"
+    ]
    },
    "outputs": [],
    "source": [
-    "# HIDDEN\n",
     "from datascience import *\n",
     "%matplotlib inline\n",
     "path_data = '../../../../data/'\n",

--- a/content/chapters/13/4/Using_Confidence_Intervals.ipynb
+++ b/content/chapters/13/4/Using_Confidence_Intervals.ipynb
@@ -4,11 +4,13 @@
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "tags": [
+     "remove_cell"
+    ]
    },
    "outputs": [],
    "source": [
-    "# HIDDEN\n",
     "from datascience import *\n",
     "%matplotlib inline\n",
     "path_data = '../../../../data/'\n",

--- a/content/chapters/13/Estimation.ipynb
+++ b/content/chapters/13/Estimation.ipynb
@@ -4,11 +4,13 @@
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "tags": [
+     "remove_cell"
+    ]
    },
    "outputs": [],
    "source": [
-    "# HIDDEN\n",
     "from datascience import *\n",
     "%matplotlib inline\n",
     "path_data = '../../../data/'\n",

--- a/content/chapters/14/1/Properties_of_the_Mean.ipynb
+++ b/content/chapters/14/1/Properties_of_the_Mean.ipynb
@@ -3,10 +3,13 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "remove_cell"
+    ]
+   },
    "outputs": [],
    "source": [
-    "# HIDDEN\n",
     "from datascience import *\n",
     "%matplotlib inline\n",
     "path_data = '../../../../data/'\n",
@@ -264,7 +267,11 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "remove_cell"
+    ]
+   },
    "outputs": [
     {
      "data": {
@@ -278,7 +285,6 @@
     }
    ],
    "source": [
-    "# HIDDEN\n",
     "\n",
     "t = Table().with_columns(\n",
     "    'Value', make_array(2, 3, 9),\n",
@@ -304,7 +310,11 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "remove_cell"
+    ]
+   },
    "outputs": [
     {
      "data": {
@@ -318,7 +328,6 @@
     }
    ],
    "source": [
-    "# HIDDEN\n",
     "\n",
     "mean = sum(t.column('Value')*t.column('Proportion'))\n",
     "t.hist(bin_column='Value', bins=np.arange(1.5, 9.6, 1))\n",
@@ -352,7 +361,11 @@
   {
    "cell_type": "code",
    "execution_count": 13,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "remove_cell"
+    ]
+   },
    "outputs": [
     {
      "data": {
@@ -366,7 +379,6 @@
     }
    ],
    "source": [
-    "# HIDDEN\n",
     "\n",
     "t2 = Table().with_columns(\n",
     "        'Value', make_array(2, 3, 4, 9),\n",
@@ -432,7 +444,11 @@
   {
    "cell_type": "code",
    "execution_count": 16,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "remove_cell"
+    ]
+   },
    "outputs": [
     {
      "data": {
@@ -446,7 +462,6 @@
     }
    ],
    "source": [
-    "# HIDDEN\n",
     "\n",
     "t2 = t2.with_column(\n",
     "        'not_symmetric', make_array(0.25, 0.5, 0, 0.25)\n",

--- a/content/chapters/14/2/Variability.ipynb
+++ b/content/chapters/14/2/Variability.ipynb
@@ -4,11 +4,13 @@
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "tags": [
+     "remove_cell"
+    ]
    },
    "outputs": [],
    "source": [
-    "# HIDDEN\n",
     "from datascience import *\n",
     "%matplotlib inline\n",
     "path_data = '../../../../data/'\n",

--- a/content/chapters/14/3/SD_and_the_Normal_Curve.ipynb
+++ b/content/chapters/14/3/SD_and_the_Normal_Curve.ipynb
@@ -4,11 +4,13 @@
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "tags": [
+     "remove_cell"
+    ]
    },
    "outputs": [],
    "source": [
-    "# HIDDEN\n",
     "from datascience import *\n",
     "%matplotlib inline\n",
     "path_data = '../../../../data/'\n",
@@ -173,7 +175,10 @@
    "cell_type": "code",
    "execution_count": 6,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "tags": [
+     "remove_cell"
+    ]
    },
    "outputs": [
     {
@@ -188,7 +193,6 @@
     }
    ],
    "source": [
-    "# HIDDEN\n",
     "# The standard normal curve\n",
     "\n",
     "plot_normal_cdf()"
@@ -248,7 +252,10 @@
    "cell_type": "code",
    "execution_count": 8,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "tags": [
+     "remove_cell"
+    ]
    },
    "outputs": [
     {
@@ -263,7 +270,6 @@
     }
    ],
    "source": [
-    "# HIDDEN\n",
     "# Area under the standard normal curve, below 1\n",
     "\n",
     "plot_normal_cdf(1)"
@@ -311,7 +317,10 @@
    "cell_type": "code",
    "execution_count": 10,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "tags": [
+     "remove_cell"
+    ]
    },
    "outputs": [
     {
@@ -326,7 +335,6 @@
     }
    ],
    "source": [
-    "# HIDDEN\n",
     "# Area under the standard normal curve, above 1\n",
     "\n",
     "plot_normal_cdf(lbound=1)"
@@ -365,7 +373,10 @@
    "cell_type": "code",
    "execution_count": 12,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "tags": [
+     "remove_cell"
+    ]
    },
    "outputs": [
     {
@@ -380,7 +391,6 @@
     }
    ],
    "source": [
-    "# HIDDEN\n",
     "# Area under the standard normal curve, between -1 and 1\n",
     "\n",
     "plot_normal_cdf(1, lbound=-1)"
@@ -428,7 +438,10 @@
    "cell_type": "code",
    "execution_count": 14,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "tags": [
+     "remove_cell"
+    ]
    },
    "outputs": [
     {
@@ -443,7 +456,6 @@
     }
    ],
    "source": [
-    "# HIDDEN\n",
     "# Area under the standard normal curve, between -2 and 2\n",
     "\n",
     "plot_normal_cdf(2, lbound=-2)"

--- a/content/chapters/14/4/Central_Limit_Theorem.ipynb
+++ b/content/chapters/14/4/Central_Limit_Theorem.ipynb
@@ -3,10 +3,13 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "remove_cell"
+    ]
+   },
    "outputs": [],
    "source": [
-    "# HIDDEN\n",
     "from datascience import *\n",
     "%matplotlib inline\n",
     "path_data = '../../../../data/'\n",
@@ -20,10 +23,13 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "remove_cell"
+    ]
+   },
    "outputs": [],
    "source": [
-    "# HIDDEN\n",
     "\n",
     "colors = Table.read_table(path_data + 'roulette_wheel.csv').column('Color')\n",
     "pockets = make_array('0','00')\n",

--- a/content/chapters/14/5/Variability_of_the_Sample_Mean.ipynb
+++ b/content/chapters/14/5/Variability_of_the_Sample_Mean.ipynb
@@ -4,11 +4,13 @@
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "tags": [
+     "remove_cell"
+    ]
    },
    "outputs": [],
    "source": [
-    "# HIDDEN\n",
     "from datascience import *\n",
     "import numpy as np\n",
     "path_data = '../../../../data/'\n",
@@ -70,7 +72,11 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "remove_cell"
+    ]
+   },
    "outputs": [
     {
      "name": "stderr",
@@ -93,7 +99,6 @@
     }
    ],
    "source": [
-    "# HIDDEN\n",
     "delay.hist(bins=np.arange(-20, 300, 10))\n",
     "plots.scatter(pop_mean, -0.0008, marker='^', color='darkblue', s=60)\n",
     "plots.ylim(-0.004, 0.04);"

--- a/content/chapters/14/6/Choosing_a_Sample_Size.ipynb
+++ b/content/chapters/14/6/Choosing_a_Sample_Size.ipynb
@@ -4,11 +4,13 @@
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "tags": [
+     "remove_cell"
+    ]
    },
    "outputs": [],
    "source": [
-    "# HIDDEN\n",
     "from datascience import *\n",
     "import numpy as np\n",
     "path_data = '../../../../data/'\n",

--- a/content/chapters/15/1/Correlation.ipynb
+++ b/content/chapters/15/1/Correlation.ipynb
@@ -4,11 +4,13 @@
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "tags": [
+     "remove_cell"
+    ]
    },
    "outputs": [],
    "source": [
-    "# HIDDEN\n",
     "from datascience import *\n",
     "%matplotlib inline\n",
     "path_data = '../../../../data/'\n",
@@ -23,11 +25,13 @@
    "cell_type": "code",
    "execution_count": 2,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "tags": [
+     "remove_cell"
+    ]
    },
    "outputs": [],
    "source": [
-    "# HIDDEN\n",
     "def r_scatter(r):\n",
     "    plots.figure(figsize=(5,5))\n",
     "    \"Generate a scatter plot with a correlation approximately r\"\n",
@@ -1262,7 +1266,10 @@
    "cell_type": "code",
    "execution_count": 36,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "tags": [
+     "remove_cell"
+    ]
    },
    "outputs": [
     {
@@ -1278,7 +1285,6 @@
     }
    ],
    "source": [
-    "# HIDDEN\n",
     "\n",
     "from IPython.display import Image\n",
     "Image(\"../../../images/chocoNobel.png\")"

--- a/content/chapters/15/2/Regression_Line.ipynb
+++ b/content/chapters/15/2/Regression_Line.ipynb
@@ -4,11 +4,13 @@
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "tags": [
+     "remove_cell"
+    ]
    },
    "outputs": [],
    "source": [
-    "# HIDDEN\n",
     "from datascience import *\n",
     "import numpy as np\n",
     "path_data = '../../../../data/'\n",
@@ -320,7 +322,11 @@
   {
    "cell_type": "code",
    "execution_count": 13,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "remove_cell"
+    ]
+   },
    "outputs": [
     {
      "data": {
@@ -334,7 +340,6 @@
     }
    ],
    "source": [
-    "# HIDDEN\n",
     "r = 0.5\n",
     "x_demo = np.random.normal(0, 1, 10000)\n",
     "z_demo = np.random.normal(0, 1, 10000)\n",
@@ -360,7 +365,11 @@
   {
    "cell_type": "code",
    "execution_count": 14,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "remove_cell"
+    ]
+   },
    "outputs": [
     {
      "data": {
@@ -374,7 +383,6 @@
     }
    ],
    "source": [
-    "# HIDDEN\n",
     "r = 0.5\n",
     "x_demo = np.random.normal(0, 1, 10000)\n",
     "z_demo = np.random.normal(0, 1, 10000)\n",
@@ -400,7 +408,11 @@
   {
    "cell_type": "code",
    "execution_count": 15,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "remove_cell"
+    ]
+   },
    "outputs": [
     {
      "data": {
@@ -414,7 +426,6 @@
     }
    ],
    "source": [
-    "# HIDDEN\n",
     "r = 0.5\n",
     "x_demo = np.random.normal(0, 1, 10000)\n",
     "z_demo = np.random.normal(0, 1, 10000)\n",
@@ -455,11 +466,13 @@
    "cell_type": "code",
    "execution_count": 16,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "tags": [
+     "remove_cell"
+    ]
    },
    "outputs": [],
    "source": [
-    "# HIDDEN\n",
     "\n",
     "def regression_line(r):\n",
     "    x = np.random.normal(0, 1, 10000)\n",

--- a/content/chapters/15/3/Method_of_Least_Squares.ipynb
+++ b/content/chapters/15/3/Method_of_Least_Squares.ipynb
@@ -6,11 +6,13 @@
    "metadata": {
     "collapsed": true,
     "deletable": true,
-    "editable": true
+    "editable": true,
+    "tags": [
+     "remove_cell"
+    ]
    },
    "outputs": [],
    "source": [
-    "# HIDDEN\n",
     "from datascience import *\n",
     "%matplotlib inline\n",
     "path_data = '../../../../data/'\n",
@@ -25,11 +27,13 @@
    "metadata": {
     "collapsed": true,
     "deletable": true,
-    "editable": true
+    "editable": true,
+    "tags": [
+     "remove_cell"
+    ]
    },
    "outputs": [],
    "source": [
-    "# HIDDEN\n",
     "\n",
     "def standard_units(any_numbers):\n",
     "    \"Convert any array of numbers to standard units.\"\n",
@@ -361,11 +365,13 @@
    "metadata": {
     "collapsed": true,
     "deletable": true,
-    "editable": true
+    "editable": true,
+    "tags": [
+     "remove_cell"
+    ]
    },
    "outputs": [],
    "source": [
-    "# HIDDEN\n",
     "\n",
     "sample = [[131, 14431], [231, 20558], [392, 40935], [157, 23524]]\n",
     "def lw_errors(slope, intercept):\n",

--- a/content/chapters/15/4/Least_Squares_Regression.ipynb
+++ b/content/chapters/15/4/Least_Squares_Regression.ipynb
@@ -6,11 +6,13 @@
    "metadata": {
     "collapsed": true,
     "deletable": true,
-    "editable": true
+    "editable": true,
+    "tags": [
+     "remove_cell"
+    ]
    },
    "outputs": [],
    "source": [
-    "# HIDDEN\n",
     "from datascience import *\n",
     "%matplotlib inline\n",
     "path_data = '../../../../data/'\n",
@@ -25,11 +27,13 @@
    "metadata": {
     "collapsed": true,
     "deletable": true,
-    "editable": true
+    "editable": true,
+    "tags": [
+     "remove_cell"
+    ]
    },
    "outputs": [],
    "source": [
-    "# HIDDEN\n",
     "\n",
     "def standard_units(any_numbers):\n",
     "    \"Convert any array of numbers to standard units.\"\n",

--- a/content/chapters/15/5/Visual_Diagnostics.ipynb
+++ b/content/chapters/15/5/Visual_Diagnostics.ipynb
@@ -4,11 +4,13 @@
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "tags": [
+     "remove_cell"
+    ]
    },
    "outputs": [],
    "source": [
-    "# HIDDEN\n",
     "\n",
     "from datascience import *\n",
     "path_data = '../../../../data/'\n",
@@ -44,11 +46,13 @@
    "cell_type": "code",
    "execution_count": 3,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "tags": [
+     "remove_cell"
+    ]
    },
    "outputs": [],
    "source": [
-    "# HIDDEN\n",
     "\n",
     "def standard_units(x):\n",
     "    return (x - np.mean(x))/np.std(x)\n",

--- a/content/chapters/15/6/Numerical_Diagnostics.ipynb
+++ b/content/chapters/15/6/Numerical_Diagnostics.ipynb
@@ -4,11 +4,13 @@
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "tags": [
+     "remove_cell"
+    ]
    },
    "outputs": [],
    "source": [
-    "# HIDDEN\n",
     "\n",
     "from datascience import *\n",
     "path_data = '../../../../data/'\n",
@@ -46,11 +48,13 @@
    "cell_type": "code",
    "execution_count": 3,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "tags": [
+     "remove_cell"
+    ]
    },
    "outputs": [],
    "source": [
-    "# HIDDEN\n",
     "\n",
     "def standard_units(x):\n",
     "    return (x - np.mean(x))/np.std(x)\n",
@@ -102,11 +106,13 @@
    "cell_type": "code",
    "execution_count": 4,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "tags": [
+     "remove_cell"
+    ]
    },
    "outputs": [],
    "source": [
-    "# HIDDEN\n",
     "heights = heights.with_columns(\n",
     "        'Fitted Value', fit(heights, 'MidParent', 'Child'),\n",
     "        'Residual', residual(heights, 'MidParent', 'Child')\n",

--- a/content/chapters/15/Prediction.ipynb
+++ b/content/chapters/15/Prediction.ipynb
@@ -4,11 +4,13 @@
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "tags": [
+     "remove_cell"
+    ]
    },
    "outputs": [],
    "source": [
-    "# HIDDEN\n",
     "from datascience import *\n",
     "import matplotlib\n",
     "path_data = '../../../data/'\n",

--- a/content/chapters/16/1/Regression_Model.ipynb
+++ b/content/chapters/16/1/Regression_Model.ipynb
@@ -6,11 +6,13 @@
    "metadata": {
     "collapsed": true,
     "deletable": true,
-    "editable": true
+    "editable": true,
+    "tags": [
+     "remove_cell"
+    ]
    },
    "outputs": [],
    "source": [
-    "# HIDDEN\n",
     "\n",
     "from datascience import *\n",
     "path_data = '../../../../data/'\n",
@@ -28,11 +30,13 @@
    "metadata": {
     "collapsed": true,
     "deletable": true,
-    "editable": true
+    "editable": true,
+    "tags": [
+     "remove_cell"
+    ]
    },
    "outputs": [],
    "source": [
-    "# HIDDEN\n",
     "\n",
     "def standard_units(any_numbers):\n",
     "    \"Convert any array of numbers to standard units.\"\n",
@@ -104,11 +108,13 @@
    "metadata": {
     "collapsed": true,
     "deletable": true,
-    "editable": true
+    "editable": true,
+    "tags": [
+     "remove_cell"
+    ]
    },
    "outputs": [],
    "source": [
-    "# HIDDEN\n",
     "\n",
     "def draw_and_compare(true_slope, true_int, sample_size):\n",
     "    x = np.random.normal(50, 5, sample_size)\n",

--- a/content/chapters/16/2/Inference_for_the_True_Slope.ipynb
+++ b/content/chapters/16/2/Inference_for_the_True_Slope.ipynb
@@ -3,10 +3,13 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "remove_cell"
+    ]
+   },
    "outputs": [],
    "source": [
-    "# HIDDEN\n",
     "\n",
     "from datascience import *\n",
     "path_data = '../../../../data/'\n",
@@ -22,10 +25,13 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "remove_cell"
+    ]
+   },
    "outputs": [],
    "source": [
-    "# HIDDEN\n",
     "\n",
     "def standard_units(any_numbers):\n",
     "    \"Convert any array of numbers to standard units.\"\n",
@@ -60,10 +66,13 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "remove_cell"
+    ]
+   },
    "outputs": [],
    "source": [
-    "# HIDDEN\n",
     "\n",
     "def draw_and_compare(true_slope, true_int, sample_size):\n",
     "    x = np.random.normal(50, 5, sample_size)\n",
@@ -102,10 +111,13 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "remove_cell"
+    ]
+   },
    "outputs": [],
    "source": [
-    "# HIDDEN\n",
     "\n",
     "baby = Table.read_table(path_data + 'baby.csv')"
    ]
@@ -214,7 +226,11 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "remove_cell"
+    ]
+   },
    "outputs": [
     {
      "data": {
@@ -228,7 +244,6 @@
     }
    ],
    "source": [
-    "# HIDDEN\n",
     "\n",
     "plots.figure(figsize=(8, 18))\n",
     "plots.subplot(5, 1, 1)\n",

--- a/content/chapters/16/3/Prediction_Intervals.ipynb
+++ b/content/chapters/16/3/Prediction_Intervals.ipynb
@@ -6,11 +6,13 @@
    "metadata": {
     "collapsed": true,
     "deletable": true,
-    "editable": true
+    "editable": true,
+    "tags": [
+     "remove_cell"
+    ]
    },
    "outputs": [],
    "source": [
-    "# HIDDEN\n",
     "\n",
     "from datascience import *\n",
     "path_data = '../../../../data/'\n",
@@ -28,11 +30,13 @@
    "metadata": {
     "collapsed": false,
     "deletable": true,
-    "editable": true
+    "editable": true,
+    "tags": [
+     "remove_cell"
+    ]
    },
    "outputs": [],
    "source": [
-    "# HIDDEN\n",
     "\n",
     "baby = Table.read_table(path_data + 'baby.csv')"
    ]
@@ -43,11 +47,13 @@
    "metadata": {
     "collapsed": true,
     "deletable": true,
-    "editable": true
+    "editable": true,
+    "tags": [
+     "remove_cell"
+    ]
    },
    "outputs": [],
    "source": [
-    "# HIDDEN\n",
     "\n",
     "def standard_units(any_numbers):\n",
     "    \"Convert any array of numbers to standard units.\"\n",
@@ -120,7 +126,10 @@
    "metadata": {
     "collapsed": false,
     "deletable": true,
-    "editable": true
+    "editable": true,
+    "tags": [
+     "remove_cell"
+    ]
    },
    "outputs": [
     {
@@ -135,7 +144,6 @@
     }
    ],
    "source": [
-    "# HIDDEN\n",
     "\n",
     "scatter_fit(baby, 'Gestational Days', 'Birth Weight')\n",
     "s = slope(baby, 'Gestational Days', 'Birth Weight')\n",
@@ -584,7 +592,10 @@
    "metadata": {
     "collapsed": false,
     "deletable": true,
-    "editable": true
+    "editable": true,
+    "tags": [
+     "remove_cell"
+    ]
    },
    "outputs": [
     {
@@ -599,7 +610,6 @@
     }
    ],
    "source": [
-    "# HIDDEN\n",
     "\n",
     "x1 = 300\n",
     "x2 = 285\n",

--- a/content/chapters/16/Inference_for_Regression.ipynb
+++ b/content/chapters/16/Inference_for_Regression.ipynb
@@ -6,11 +6,13 @@
    "metadata": {
     "collapsed": true,
     "deletable": true,
-    "editable": true
+    "editable": true,
+    "tags": [
+     "remove_cell"
+    ]
    },
    "outputs": [],
    "source": [
-    "# HIDDEN\n",
     "\n",
     "from datascience import *\n",
     "path_data = '../../../data/'\n",

--- a/content/chapters/17/1/Nearest_Neighbors.ipynb
+++ b/content/chapters/17/1/Nearest_Neighbors.ipynb
@@ -4,11 +4,13 @@
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "tags": [
+     "remove_cell"
+    ]
    },
    "outputs": [],
    "source": [
-    "# HIDDEN\n",
     "import matplotlib\n",
     "#matplotlib.use('Agg')\n",
     "path_data = '../../../../data/'\n",
@@ -26,11 +28,13 @@
    "cell_type": "code",
    "execution_count": 2,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "tags": [
+     "remove_cell"
+    ]
    },
    "outputs": [],
    "source": [
-    "# HIDDEN\n",
     "\n",
     "def standard_units(x):\n",
     "    return (x - np.mean(x))/np.std(x)"
@@ -40,11 +44,13 @@
    "cell_type": "code",
    "execution_count": 3,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "tags": [
+     "remove_cell"
+    ]
    },
    "outputs": [],
    "source": [
-    "# HIDDEN\n",
     "\n",
     "def distance(point1, point2):\n",
     "    \"\"\"The distance between two arrays of numbers.\"\"\"\n",
@@ -350,11 +356,13 @@
    "cell_type": "code",
    "execution_count": 9,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "tags": [
+     "remove_cell"
+    ]
    },
    "outputs": [],
    "source": [
-    "# HIDDEN\n",
     "\n",
     "def show_closest(point):\n",
     "    \"\"\"point = array([x,y]) \n",
@@ -450,11 +458,13 @@
    "cell_type": "code",
    "execution_count": 12,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "tags": [
+     "remove_cell"
+    ]
    },
    "outputs": [],
    "source": [
-    "# HIDDEN\n",
     "\n",
     "x_array = make_array()\n",
     "y_array = make_array()\n",
@@ -473,7 +483,10 @@
    "cell_type": "code",
    "execution_count": 13,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "tags": [
+     "remove_cell"
+    ]
    },
    "outputs": [
     {
@@ -488,7 +501,6 @@
     }
    ],
    "source": [
-    "# HIDDEN\n",
     "\n",
     "test_grid.scatter('Hemoglobin', 'Glucose', color='red', alpha=0.4, s=30)\n",
     "\n",
@@ -515,11 +527,13 @@
    "cell_type": "code",
    "execution_count": 14,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "tags": [
+     "remove_cell"
+    ]
    },
    "outputs": [],
    "source": [
-    "# HIDDEN\n",
     "\n",
     "def classify_grid(training, test, k):\n",
     "    c = make_array()\n",
@@ -533,11 +547,13 @@
    "cell_type": "code",
    "execution_count": 15,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "tags": [
+     "remove_cell"
+    ]
    },
    "outputs": [],
    "source": [
-    "# HIDDEN\n",
     "\n",
     "c = classify_grid(ckd.drop('White Blood Cell Count', 'Color'), test_grid, 1)"
    ]
@@ -546,7 +562,10 @@
    "cell_type": "code",
    "execution_count": 16,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "tags": [
+     "remove_cell"
+    ]
    },
    "outputs": [
     {
@@ -561,7 +580,6 @@
     }
    ],
    "source": [
-    "# HIDDEN\n",
     "\n",
     "test_grid = test_grid.with_column('Class', c).join('Class', color_table)\n",
     "test_grid.scatter('Hemoglobin', 'Glucose', colors='Color', alpha=0.4, s=30)\n",

--- a/content/chapters/17/2/Training_and_Testing.ipynb
+++ b/content/chapters/17/2/Training_and_Testing.ipynb
@@ -4,11 +4,13 @@
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "tags": [
+     "remove_cell"
+    ]
    },
    "outputs": [],
    "source": [
-    "# HIDDEN\n",
     "import matplotlib\n",
     "#matplotlib.use('Agg')\n",
     "path_data = '../../../../data/'\n",
@@ -26,11 +28,13 @@
    "cell_type": "code",
    "execution_count": 2,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "tags": [
+     "remove_cell"
+    ]
    },
    "outputs": [],
    "source": [
-    "# HIDDEN\n",
     "\n",
     "def standard_units(x):\n",
     "    return (x - np.mean(x))/np.std(x)"
@@ -40,13 +44,14 @@
    "cell_type": "code",
    "execution_count": 3,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "tags": [
+     "remove_cell"
+    ]
    },
    "outputs": [],
    "source": [
-    "# HIDDEN\n",
     "\n",
-    "# HIDDEN\n",
     "\n",
     "def distance(pt1, pt2):\n",
     "    return np.sqrt(np.sum((pt1 - pt2)**2))\n",
@@ -84,11 +89,13 @@
    "cell_type": "code",
    "execution_count": 4,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "tags": [
+     "remove_cell"
+    ]
    },
    "outputs": [],
    "source": [
-    "# HIDDEN\n",
     "\n",
     "def classify_grid(training, test, k):\n",
     "    c = make_array()\n",
@@ -271,11 +278,13 @@
    "cell_type": "code",
    "execution_count": 9,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "tags": [
+     "remove_cell"
+    ]
    },
    "outputs": [],
    "source": [
-    "# HIDDEN\n",
     "\n",
     "x_array = make_array()\n",
     "y_array = make_array()\n",
@@ -294,11 +303,13 @@
    "cell_type": "code",
    "execution_count": 10,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "tags": [
+     "remove_cell"
+    ]
    },
    "outputs": [],
    "source": [
-    "# HIDDEN\n",
     "\n",
     "c = classify_grid(training.drop('Hemoglobin', 'Color'), test_grid, 1)"
    ]
@@ -307,7 +318,10 @@
    "cell_type": "code",
    "execution_count": 11,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "tags": [
+     "remove_cell"
+    ]
    },
    "outputs": [
     {
@@ -322,7 +336,6 @@
     }
    ],
    "source": [
-    "# HIDDEN\n",
     "\n",
     "test_grid = test_grid.with_column('Class', c).join('Class', color_table)\n",
     "test_grid.scatter('White Blood Cell Count', 'Glucose', colors='Color', alpha=0.4, s=30)\n",
@@ -342,7 +355,10 @@
    "cell_type": "code",
    "execution_count": 12,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "tags": [
+     "remove_cell"
+    ]
    },
    "outputs": [
     {
@@ -357,7 +373,6 @@
     }
    ],
    "source": [
-    "# HIDDEN\n",
     "\n",
     "test_grid = test_grid.with_column('Class', c).join('Class', color_table)\n",
     "test_grid.scatter('White Blood Cell Count', 'Glucose', colors='Color', alpha=0.4, s=30)\n",

--- a/content/chapters/17/3/Rows_of_Tables.ipynb
+++ b/content/chapters/17/3/Rows_of_Tables.ipynb
@@ -4,11 +4,13 @@
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "tags": [
+     "remove_cell"
+    ]
    },
    "outputs": [],
    "source": [
-    "# HIDDEN\n",
     "import matplotlib\n",
     "#matplotlib.use('Agg')\n",
     "path_data = '../../../../data/'\n",
@@ -26,11 +28,13 @@
    "cell_type": "code",
    "execution_count": 2,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "tags": [
+     "remove_cell"
+    ]
    },
    "outputs": [],
    "source": [
-    "# HIDDEN\n",
     "\n",
     "def standard_units(x):\n",
     "    return (x - np.mean(x))/np.std(x)"
@@ -1004,7 +1008,10 @@
    "cell_type": "code",
    "execution_count": 27,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "tags": [
+     "remove_cell"
+    ]
    },
    "outputs": [
     {
@@ -1019,7 +1026,6 @@
     }
    ],
    "source": [
-    "# HIDDEN\n",
     "plots.figure(figsize=(8,8))\n",
     "plots.scatter(ckd.column('Hemoglobin'), ckd.column('Glucose'), c=ckd.column('Color'), s=40)\n",
     "#ckd.scatter('Hemoglobin', 'Glucose', colors='Color')\n",

--- a/content/chapters/17/4/Implementing_the_Classifier.ipynb
+++ b/content/chapters/17/4/Implementing_the_Classifier.ipynb
@@ -4,11 +4,13 @@
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "tags": [
+     "remove_cell"
+    ]
    },
    "outputs": [],
    "source": [
-    "# HIDDEN\n",
     "import matplotlib\n",
     "#matplotlib.use('Agg')\n",
     "path_data = '../../../../data/'\n",

--- a/content/chapters/17/5/Accuracy_of_the_Classifier.ipynb
+++ b/content/chapters/17/5/Accuracy_of_the_Classifier.ipynb
@@ -3,10 +3,13 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "remove_cell"
+    ]
+   },
    "outputs": [],
    "source": [
-    "# HIDDEN\n",
     "import matplotlib\n",
     "#matplotlib.use('Agg')\n",
     "path_data = '../../../../data/'\n",
@@ -24,11 +27,13 @@
    "cell_type": "code",
    "execution_count": 2,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "tags": [
+     "remove_cell"
+    ]
    },
    "outputs": [],
    "source": [
-    "# HIDDEN\n",
     "\n",
     "def distance(point1, point2):\n",
     "    \"\"\"Returns the distance between point1 and point2\n",
@@ -75,10 +80,13 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "remove_cell"
+    ]
+   },
    "outputs": [],
    "source": [
-    "# HIDDEN\n",
     "\n",
     "wine = Table.read_table(path_data + 'wine.csv')\n",
     "\n",
@@ -339,7 +347,11 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "remove_cell"
+    ]
+   },
    "outputs": [
     {
      "data": {
@@ -353,7 +365,6 @@
     }
    ],
    "source": [
-    "# HIDDEN\n",
     "\n",
     "def randomize_column(a):\n",
     "    return a + np.random.normal(0.0, 0.09, size=len(a))\n",

--- a/content/chapters/17/6/Multiple_Regression.ipynb
+++ b/content/chapters/17/6/Multiple_Regression.ipynb
@@ -6,11 +6,13 @@
    "metadata": {
     "collapsed": true,
     "deletable": true,
-    "editable": true
+    "editable": true,
+    "tags": [
+     "remove_cell"
+    ]
    },
    "outputs": [],
    "source": [
-    "# HIDDEN\n",
     "\n",
     "from datascience import *\n",
     "path_data = '../../../../data/'\n",
@@ -27,11 +29,13 @@
    "cell_type": "code",
    "execution_count": 2,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "tags": [
+     "remove_cell"
+    ]
    },
    "outputs": [],
    "source": [
-    "# HIDDEN\n",
     "\n",
     "def standard_units(any_numbers):\n",
     "    \"Convert any array of numbers to standard units.\"\n",

--- a/content/chapters/17/Classification.ipynb
+++ b/content/chapters/17/Classification.ipynb
@@ -6,11 +6,13 @@
    "metadata": {
     "collapsed": false,
     "deletable": true,
-    "editable": true
+    "editable": true,
+    "tags": [
+     "remove_cell"
+    ]
    },
    "outputs": [],
    "source": [
-    "# HIDDEN\n",
     "import matplotlib\n",
     "#matplotlib.use('Agg')\n",
     "path_data = '../../../data/'\n",

--- a/content/chapters/18/1/More_Likely_than_Not_Binary_Classifier.ipynb
+++ b/content/chapters/18/1/More_Likely_than_Not_Binary_Classifier.ipynb
@@ -4,11 +4,13 @@
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "tags": [
+     "remove_cell"
+    ]
    },
    "outputs": [],
    "source": [
-    "# HIDDEN\n",
     "import matplotlib\n",
     "from datascience import *\n",
     "path_data = '../../../../data/'\n",
@@ -59,11 +61,13 @@
    "cell_type": "code",
    "execution_count": 2,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "tags": [
+     "remove_cell"
+    ]
    },
    "outputs": [],
    "source": [
-    "# HIDDEN\n",
     "year = np.array(['Second']*60 + ['Third']*40)\n",
     "major = np.array(['Undeclared']*30+['Declared']*30+['Undeclared']*8+['Declared']*32)\n",
     "students = Table().with_columns(\n",

--- a/content/chapters/18/2/Making_Decisions.ipynb
+++ b/content/chapters/18/2/Making_Decisions.ipynb
@@ -4,11 +4,13 @@
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "tags": [
+     "remove_cell"
+    ]
    },
    "outputs": [],
    "source": [
-    "# HIDDEN\n",
     "import matplotlib\n",
     "from datascience import *\n",
     "path_data = '../../../../data/'\n",
@@ -22,11 +24,13 @@
    "cell_type": "code",
    "execution_count": 2,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "tags": [
+     "remove_cell"
+    ]
    },
    "outputs": [],
    "source": [
-    "# HIDDEN\n",
     "def population(prior_prob_disease):\n",
     "    n_d = int(prior_prob_disease*100000)\n",
     "    n_nd = 100000 - n_d\n",

--- a/content/chapters/18/Updating_Predictions.ipynb
+++ b/content/chapters/18/Updating_Predictions.ipynb
@@ -4,11 +4,13 @@
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "tags": [
+     "remove_cell"
+    ]
    },
    "outputs": [],
    "source": [
-    "# HIDDEN\n",
     "import matplotlib\n",
     "from datascience import *\n",
     "path_data = '../../../data/'\n",


### PR DESCRIPTION
In #111 @davidwagner noticed that the behavior of the "# HIDDEN" cells changed. That's because Jupyter Book uses tags now instead of parsing the cell text for phrases. This PR removes "# HIDDEN" from each cell and replaces it with a `hide_cell` tag in the cell's metadata.