### PR TITLE
fixed broken link to federal employment stats in 3.2.1

### DIFF
--- a/content/chapters/03/2/1/Growth.ipynb
+++ b/content/chapters/03/2/1/Growth.ipynb
@@ -6,7 +6,7 @@
    "source": [
     "# Example: Growth Rates\n",
     "\n",
-    "The relationship between two measurements of the same quantity taken at different times is often expressed as a *growth rate*. For example, the United States federal government [employed](http://www.bls.gov/opub/mlr/2013/article/industry-employment-and-output-projections-to-2022-1.htm) 2,766,000 people in 2002 and 2,814,000 people in 2012. To compute a growth rate, we must first decide which value to treat as the `initial` amount. For values over time, the earlier value is a natural choice. Then, we divide the difference between the `changed` and `initial` amount by the `initial` amount."
+    "The relationship between two measurements of the same quantity taken at different times is often expressed as a *growth rate*. For example, the United States federal government [employed](https://www.bls.gov/opub/mlr/2013/article/industry-employment-and-output-projections-to-2022.htm) 2,766,000 people in 2002 and 2,814,000 people in 2012. To compute a growth rate, we must first decide which value to treat as the `initial` amount. For values over time, the earlier value is a natural choice. Then, we divide the difference between the `changed` and `initial` amount by the `initial` amount."
    ]
   },
   {


### PR DESCRIPTION
Fixed broken link in `contents` as documented in https://github.com/data-8/textbook/issues/132