### PR TITLE
Fixing small typo in Ch 12 A/B testing jupyter notebook

### DIFF
--- a/content/chapters/12/1/AB_Testing.ipynb
+++ b/content/chapters/12/1/AB_Testing.ipynb
@@ -212,7 +212,7 @@
    "metadata": {},
    "source": [
     "### The Hypotheses ###\n",
-    "We can try to answer this question by a test of hypotheses. The chance model that we will test says that there is no underlying difference in the popuations; the distributions in the samples are different just due to chance. \n",
+    "We can try to answer this question by a test of hypotheses. The chance model that we will test says that there is no underlying difference in the populations; the distributions in the samples are different just due to chance. \n",
     "\n",
     "Formally, this is the null hypothesis. We are going to have to figure out how to simulate a useful statistic under this hypothesis. But as a start, let's just state the two natural hypotheses.\n",
     "\n",
@@ -962,7 +962,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.8"
+   "version": "3.8.2"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Fixing typo popuations to populations in Jupyter notebook in chaper 12 A/B testing