### PR TITLE
Fix textbook logo link

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -36,7 +36,7 @@ footer_text: This page was created by <a href="https://github.com/jupyter/jupyte
 show_sidebar: true                # Show the sidebar. Only set to false if your only wish to host a single page.
 collapse_inactive_chapters: true  # Whether to collapse the inactive chapters in the sidebar
 textbook_logo: favicon.png                        # A logo to be displayed at the top of your textbook sidebar. Should be square
-textbook_logo_link: https://inferentialthinking.org                      # A link for the logo.
+textbook_logo_link: https://inferentialthinking.com                      # A link for the logo.
 sidebar_footer_text: Powered by <a href="https://github.com/choldgraf/jupyter-book">Jupyter
   Book</a>
 number_toc_chapters: true         # Whether to add numbers to chapterse in your Table of Contents. If true, you can control this at the Chapter level in _data/toc.yml


### PR DESCRIPTION
It was .org instead of .com, leads you to the wrong website