### PR TITLE
Updating folium version for binder

### DIFF
--- a/binder/requirements.txt
+++ b/binder/requirements.txt
@@ -1,7 +1,7 @@
 numpy
 pandas
 scipy
-folium==0.2.1
+folium>=0.9.1
 matplotlib
 datascience
 ipywidgets>=7.0.0


### PR DESCRIPTION
This updates folium for the textbook to be compatible with `datascience==0.17.0` which features in version `folium>=0.9.1`.