### PR TITLE
fix a typo that had *bootstrap* be *boostrap*

### DIFF
--- a/chapters/13/3/Confidence_Intervals.ipynb
+++ b/chapters/13/3/Confidence_Intervals.ipynb
@@ -27,7 +27,7 @@
     "\n",
     "In the previous example we saw that our process of estimation produced a good interval about 95% of the time, a \"good\" interval being one that contains the parameter. We say that we are *95% confident* that the process results in a good interval. Our interval of estimates is called a *95% confidence interval* for the parameter, and 95% is called the *confidence level* of the interval.\n",
     "\n",
-    "The method is called the *boostrap percentile method* because the interval is formed by picking off two percentiles of the bootstrapped estimates.\n",
+    "The method is called the *bootstrap percentile method* because the interval is formed by picking off two percentiles of the bootstrapped estimates.\n",
     "\n",
     "The situation in the previous example was a bit unusual. Because we happened to know the value of the parameter, we were able to check whether an interval was good or a dud, and this in turn helped us to see that our process of estimation captured the parameter about 95 out of every 100 times we used it.\n",
     "\n",


### PR DESCRIPTION
While I was able to make that joke in class that *boostrap* is what one calls a *bootstrap* on Halloween, this typo should be fixed.