### PR TITLE
Remove License Icons

### DIFF
--- a/myst.yml
+++ b/myst.yml
@@ -8,7 +8,8 @@ project:
     - name: Ani Adhikari
     - name: John DeNero
     - name: David Wagner
-  license: CC-BY-NC-ND-4.0
+  # Don't show the license icons on every page
+  # license: CC-BY-NC-ND-4.0
   exclude:
     - README.md
   github: data-8/textbook


### PR DESCRIPTION
closes #202. This is how it looks when I serve the book locally now:

<img width="1166" height="283" alt="Screenshot 2026-01-13 at 12 00 07 PM" src="https://github.com/user-attachments/assets/fa15e218-b298-4995-aaa6-3c6427dea8ba" />
