### PR TITLE
Fix Chapter Numbering 6-10

### DIFF
--- a/chapters/05/Sequences.ipynb
+++ b/chapters/05/Sequences.ipynb
@@ -86,11 +86,11 @@
    "source": [
     "The complete chart of daily high and low temperatures appears below. \n",
     "\n",
-    "<h2>Mean of Daily High Temperature</h2>\n",
+    "**Mean of Daily High Temperature**\n",
     "\n",
     "![Mean of Daily High Temperature](../../images/global-land-TMAX-Trend.png)\n",
     "\n",
-    "<h2>Mean of Daily Low Temperature</h2>\n",
+    "**Mean of Daily Low Temperature**\n",
     "\n",
     "![Mean of Daily Low Temperature](../../images/global-land-TMIN-Trend.png)"
    ]

--- a/chapters/06/Tables.ipynb
+++ b/chapters/06/Tables.ipynb
@@ -371,7 +371,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<h2>The Size of the Table</h2>\n",
+    "**The Size of the Table**\n",
     "\n",
     "The method `num_columns` gives the number of columns in the table, and `num_rows` the number of rows."
    ]
@@ -420,7 +420,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<h2>Column Labels</h2>\n",
+    "**Column Labels**\n",
     "\n",
     "The method `labels` can be used to list the labels of all the columns. With `minard` we don't gain much by this, but it can be very useful for tables that are so large that not all columns are visible on the screen."
    ]
@@ -660,7 +660,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<h2>Accessing the Data in a Column</h2>\n",
+    "**Accessing the Data in a Column**\n",
     "\n",
     "We can use a column's label to access the array of data in the column."
    ]
@@ -763,7 +763,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<h2>Working with the Data in a Column</h2>\n",
+    "**Working with the Data in a Column**\n",
     "\n",
     "Because columns are arrays, we can use array operations on them to discover new information. For example, we can create a new column that contains the percent of all survivors at each city after Smolensk."
    ]
@@ -909,7 +909,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<h2>Choosing Sets of Columns</h2>\n",
+    "**Choosing Sets of Columns**\n",
     "\n",
     "The method `select` creates a new table that contains only the specified columns."
    ]

--- a/chapters/07/Visualization.ipynb
+++ b/chapters/07/Visualization.ipynb
@@ -42,7 +42,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<h2>Scatter Plots and Line Graphs</h2>"
+    "**Scatter Plots and Line Graphs**"
    ]
   },
   {
@@ -153,7 +153,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<h2>Scatter Plots</h2>\n",
+    "**Scatter Plots**\n",
     "\n",
     "A *scatter plot* displays the relation between two numerical variables. You saw an example of a scatter plot in an early section where we looked at the number of periods and number of characters in two classic novels.\n",
     "\n",
@@ -380,7 +380,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<h2>Line Plots</h2>\n",
+    "**Line Plots**\n",
     "\n",
     "Line plots, sometimes known as line graphs, are among the most common visualizations. They are often used to study chronological trends and patterns.\n",
     "\n",

--- a/chapters/08/Functions_and_Tables.ipynb
+++ b/chapters/08/Functions_and_Tables.ipynb
@@ -40,7 +40,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<h2>Defining a Function</h2>\n",
+    "**Defining a Function**\n",
     "\n",
     "The definition of the `double` function below simply doubles a number."
    ]
@@ -359,7 +359,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<h2>Multiple Arguments</h2>"
+    "**Multiple Arguments**"
    ]
   },
   {
@@ -432,7 +432,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<h2>Note: Methods</h2>\n",
+    "**Note: Methods**\n",
     "\n",
     "Functions are called by placing argument expressions in parentheses after the function name. Any function that is defined in isolation is called in this way. You have also seen examples of methods, which are like functions but are called using dot notation, such as `some_table.sort(some_label)`. The functions that you define will always be called using the function name first, passing in all of the arguments."
    ]
@@ -441,7 +441,7 @@
  "metadata": {
   "anaconda-cloud": {},
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "venv-new-jb",
    "language": "python",
    "name": "python3"
   },
@@ -455,7 +455,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.9"
+   "version": "3.9.6"
   }
  },
  "nbformat": 4,

--- a/chapters/09/Randomness.ipynb
+++ b/chapters/09/Randomness.ipynb
@@ -100,7 +100,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<h2>Booleans and Comparison</h2>\n",
+    "**Booleans and Comparison**\n",
     "\n",
     "In Python, Boolean values, named for the logician [George Boole](https://en.wikipedia.org/wiki/George_Boole), represent truth and take only two possible values: `True` and `False`. Whether problems involve randomness or not, Boolean values most often arise from comparison operators. Python includes a variety of operators that compare values. For example, `3` is larger than `1 + 1`."
    ]
@@ -250,7 +250,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<h2>Comparing Strings</h2>\n",
+    "**Comparing Strings**\n",
     "\n",
     "Strings can also be compared, and their order is alphabetical. A shorter string is less than a longer string that begins with the shorter string."
    ]
@@ -313,7 +313,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<h2>Comparing an Array and a Value</h2>\n",
+    "**Comparing an Array and a Value**\n",
     "\n",
     "Recall that we can perform arithmetic operations on many numbers in an array at once.  For example, `make_array(0, 5, 2)*2` is equivalent to `make_array(0, 10, 4)`.  In similar fashion, if we compare an array and one value, each element of the array is compared to that value, and the comparison evaluates to an array of Booleans."
    ]

--- a/chapters/10/Sampling_and_Empirical_Distributions.ipynb
+++ b/chapters/10/Sampling_and_Empirical_Distributions.ipynb
@@ -111,7 +111,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<h2>Sampling Rows of a Table</h2>\n",
+    "**Sampling Rows of a Table**\n",
     "\n",
     "Each row of a data table represents an individual; in `top`, each individual is a movie. Sampling individuals can thus be achieved by sampling the rows of a table.\n",
     "\n",
@@ -122,7 +122,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<h2>Deterministic Samples</h2>\n",
+    "**Deterministic Samples**\n",
     "\n",
     "When you simply specify which elements of a set you want to choose, without any chances involved, you create a *deterministic sample*.\n",
     "\n",
@@ -249,7 +249,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<h2>Probability Samples</h2>"
+    "**Probability Samples**"
    ]
   },
   {
@@ -264,7 +264,7 @@
     "\n",
     "In a probability sample, all elements need not have the same chance of being chosen. \n",
     "\n",
-    "<h2>A Random Sampling Scheme</h2>\n",
+    "**A Random Sampling Scheme**\n",
     "\n",
     "For example, suppose you choose two people from a population that consists of three people A, B, and C, according to the following scheme:\n",
     "\n",
@@ -288,7 +288,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<h2>A Systematic Sample</h2>\n",
+    "**A Systematic Sample**\n",
     "\n",
     "Imagine all the elements of the population listed in a sequence. One method of sampling starts by choosing a random position early in the list, and then evenly spaced positions after that. The sample consists of the elements in those positions. Such a sample is called a *systematic sample*. \n",
     "\n",
@@ -387,7 +387,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<h2>Random Samples Drawn With or Without Replacement</h2>\n",
+    "**Random Samples Drawn With or Without Replacement**\n",
     " \n",
     "In this course, we will mostly deal with the two most straightforward methods of sampling. \n",
     "\n",
@@ -404,7 +404,7 @@
     "collapsed": true
    },
    "source": [
-    "<h2>Convenience Samples</h2>\n",
+    "**Convenience Samples**\n",
     "Drawing a random sample requires care and precision. It is not haphazard even though that is a colloquial meaning of the word \"random\". If you stand at a street corner and take as your sample the first ten people who pass by, you might think you're sampling at random because you didn't choose who walked by. But it's not a random sample – it's a *sample of convenience*. You didn't know ahead of time the probability of each person entering the sample; perhaps you hadn't even specified exactly who was in the population."
    ]
   },


### PR DESCRIPTION
This PR removes headings from chapter intros in order to keep numbering consistent within the chapter. See the below screenshot for the issue.

<img width="800" height="1436" alt="image" src="https://github.com/user-attachments/assets/0adfa611-745e-4881-a291-78957e70a1bd" />

**Note:** I am planning to ask for help from the Jupyter Book community to see if there's a better way to do this and ultimately keep the headings because that navigation was useful. Hopefully there's a way to force "6.0" and "6.0.1" within that chapter intro so "6.1" can be applied to the first child of the chapter.
